### PR TITLE
Add referer header

### DIFF
--- a/redditrepostsleuth/core/util/imagehashing.py
+++ b/redditrepostsleuth/core/util/imagehashing.py
@@ -36,6 +36,7 @@ def generate_img_by_url(url: str) -> Image:
         url,
         data=None,
         headers={
+            'Referer': url,
             'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.47 Safari/537.36'
         }
     )


### PR DESCRIPTION
Pixiv's image servers will respond with error 403 to any request with a Referer header that doesn't have pixiv.net as a host. You can see this by clicking on [this link](https://i.pximg.net/img-master/img/2021/04/14/20/30/01/89150224_p0_master1200.jpg). This means that Repost Sleuth can't search for images hosted by Pixiv. However, this can be remedied by always setting the Referer header to the image's URL.