### PR TITLE
Add angle brackets around links that contain spaces to increase compatibility

### DIFF
--- a/redditrepostsleuth/core/util/replytemplates.py
+++ b/redditrepostsleuth/core/util/replytemplates.py
@@ -12,7 +12,7 @@ REPOST_MESSAGE_TEMPLATE = 'Looks like a repost. I\'ve seen this {post_type} {cou
 COMMENT_STATS = '{stats_searched_post_str} | **Search Time:** {search_time}s'
 COMMENT_SIGNATURE = 'Feedback? Hate? Visit r/repostsleuthbot'
 SEARCH_URL = '[View Search On repostsleuth.com]({search_url})'
-IMAGE_REPORT_TEXT = '*I\'m not perfect, but you can help. Report [ [False {pos_neg_text}](https://www.reddit.com/message/compose/?to=RepostSleuthBot&subject=False%20{pos_neg_text}&message={report_data}) ]*'
+IMAGE_REPORT_TEXT = '*I\'m not perfect, but you can help. Report [ [False {pos_neg_text}](<https://www.reddit.com/message/compose/?to=RepostSleuthBot&subject=False%20{pos_neg_text}&message={report_data}>) ]*'
 
 LINK_OC = 'Looks like this is the first time this link has been shared on Reddit'
 LINK_REPOST = 'This link has been shared {match_count} {times_word}.\n\n' \

--- a/tests/core/services/response_builder_expected_responses.py
+++ b/tests/core/services/response_builder_expected_responses.py
@@ -1,31 +1,31 @@
 IMAGE_OC_NO_CLOSE_NO_SIG_NO_STATS_NO_SEARCH = 'I didn\'t find any posts that meet the matching requirements for r/test.\n\n' \
                               'It might be OC, it might not. Things such as JPEG artifacts and cropping may impact the results.\n\n' \
-                              '*I\'m not perfect, but you can help. Report [ [False Negative](https://www.reddit.com/message/compose/?to=RepostSleuthBot&subject=False%20Negative&message={"post_id": "abc123", "meme_template": null}) ]*'
+                              '*I\'m not perfect, but you can help. Report [ [False Negative](<https://www.reddit.com/message/compose/?to=RepostSleuthBot&subject=False%20Negative&message={"post_id": "abc123", "meme_template": null}>) ]*'
 
 IMAGE_OC_ONLY_SIGNATURE = 'I didn\'t find any posts that meet the matching requirements for r/test.\n\n' \
                     'It might be OC, it might not. Things such as JPEG artifacts and cropping may impact the results.\n\n' \
-                    'Feedback? Hate? Visit r/repostsleuthbot - *I\'m not perfect, but you can help. Report [ [False Negative](https://www.reddit.com/message/compose/?to=RepostSleuthBot&subject=False%20Negative&message={"post_id": "abc123", "meme_template": null}) ]*'
+                    'Feedback? Hate? Visit r/repostsleuthbot - *I\'m not perfect, but you can help. Report [ [False Negative](<https://www.reddit.com/message/compose/?to=RepostSleuthBot&subject=False%20Negative&message={"post_id": "abc123", "meme_template": null}>) ]*'
 
 IMAGE_OC_ONLY_STATUS = 'I didn\'t find any posts that meet the matching requirements for r/test.\n\n' \
                  'It might be OC, it might not. Things such as JPEG artifacts and cropping may impact the results.\n\n' \
-                 '*I\'m not perfect, but you can help. Report [ [False Negative](https://www.reddit.com/message/compose/?to=RepostSleuthBot&subject=False%20Negative&message={"post_id": "abc123", "meme_template": null}) ]*\n\n' \
+                 '*I\'m not perfect, but you can help. Report [ [False Negative](<https://www.reddit.com/message/compose/?to=RepostSleuthBot&subject=False%20Negative&message={"post_id": "abc123", "meme_template": null}>) ]*\n\n' \
                  '---\n\n' \
                  '**Searched Images:** 0 | **Search Time:** 10s'
 
 IMAGE_OC_LINK_ONLY = 'I didn\'t find any posts that meet the matching requirements for r/test.\n\n' \
                  'It might be OC, it might not. Things such as JPEG artifacts and cropping may impact the results.\n\n' \
-                 '*I\'m not perfect, but you can help. Report [ [False Negative](https://www.reddit.com/message/compose/?to=RepostSleuthBot&subject=False%20Negative&message={"post_id": "abc123", "meme_template": null}) ]*\n\n' \
+                 '*I\'m not perfect, but you can help. Report [ [False Negative](<https://www.reddit.com/message/compose/?to=RepostSleuthBot&subject=False%20Negative&message={"post_id": "abc123", "meme_template": null}>) ]*\n\n' \
                  '[View Search On repostsleuth.com](https://www.repostsleuth.com?postId=abc123&sameSub=false&filterOnlyOlder=true&memeFilter=false&filterDeadMatches=true&targetImageMatch=90&targetImageMemeMatch=50)'
 
 IMAGE_OC_ONLY_SEARCH_SETTINGS = 'I didn\'t find any posts that meet the matching requirements for r/test.\n\n' \
                                  'It might be OC, it might not. Things such as JPEG artifacts and cropping may impact the results.\n\n' \
-                                 '*I\'m not perfect, but you can help. Report [ [False Negative](https://www.reddit.com/message/compose/?to=RepostSleuthBot&subject=False%20Negative&message={"post_id": "abc123", "meme_template": null}) ]*\n\n' \
+                                 '*I\'m not perfect, but you can help. Report [ [False Negative](<https://www.reddit.com/message/compose/?to=RepostSleuthBot&subject=False%20Negative&message={"post_id": "abc123", "meme_template": null}>) ]*\n\n' \
                                  '---\n\n' \
                                  '**Scope:** Reddit | **Meme Filter:** False | **Target:** 90% | **Check Title:** False | **Max Age:** 190'
 
 IMAGE_OC_ALL_ENABLED = 'I didn\'t find any posts that meet the matching requirements for r/test.\n\n' \
                        'It might be OC, it might not. Things such as JPEG artifacts and cropping may impact the results.\n\n' \
-                       'Feedback? Hate? Visit r/repostsleuthbot - *I\'m not perfect, but you can help. Report [ [False Negative](https://www.reddit.com/message/compose/?to=RepostSleuthBot&subject=False%20Negative&message={"post_id": "abc123", "meme_template": null}) ]*\n\n' \
+                       'Feedback? Hate? Visit r/repostsleuthbot - *I\'m not perfect, but you can help. Report [ [False Negative](<https://www.reddit.com/message/compose/?to=RepostSleuthBot&subject=False%20Negative&message={"post_id": "abc123", "meme_template": null}>) ]*\n\n' \
                        '[View Search On repostsleuth.com](https://www.repostsleuth.com?postId=abc123&sameSub=false&filterOnlyOlder=true&memeFilter=false&filterDeadMatches=true&targetImageMatch=90&targetImageMemeMatch=50)\n\n' \
                        '---\n\n' \
                        '**Scope:** Reddit | **Meme Filter:** False | **Target:** 90% | **Check Title:** False | **Max Age:** 190' \
@@ -34,7 +34,7 @@ IMAGE_OC_ALL_ENABLED = 'I didn\'t find any posts that meet the matching requirem
 IMAGE_OC_ALL_ENABLED_ALL_ENABLED_NO_MEME = 'I didn\'t find any posts that meet the matching requirements for r/test.\n\n' \
                        'It might be OC, it might not. Things such as JPEG artifacts and cropping may impact the results.\n\n' \
                         'I did find [this post](https://redd.it/abc123) that is 84.38% similar.  It might be a match but I cannot be certain.\n\n' \
-                       'Feedback? Hate? Visit r/repostsleuthbot - *I\'m not perfect, but you can help. Report [ [False Negative](https://www.reddit.com/message/compose/?to=RepostSleuthBot&subject=False%20Negative&message={"post_id": "abc123", "meme_template": null}) ]*\n\n' \
+                       'Feedback? Hate? Visit r/repostsleuthbot - *I\'m not perfect, but you can help. Report [ [False Negative](<https://www.reddit.com/message/compose/?to=RepostSleuthBot&subject=False%20Negative&message={"post_id": "abc123", "meme_template": null}>) ]*\n\n' \
                        '[View Search On repostsleuth.com](https://www.repostsleuth.com?postId=abc123&sameSub=false&filterOnlyOlder=true&memeFilter=false&filterDeadMatches=true&targetImageMatch=90&targetImageMemeMatch=50)\n\n' \
                        '---\n\n' \
                        '**Scope:** Reddit | **Meme Filter:** False | **Target:** 90% | **Check Title:** False | **Max Age:** 190' \
@@ -42,7 +42,7 @@ IMAGE_OC_ALL_ENABLED_ALL_ENABLED_NO_MEME = 'I didn\'t find any posts that meet t
 
 IMAGE_REPOST_ONE_MATCH_ALL_ENABLED = 'Looks like a repost. I\'ve seen this image 1 time.\n\n' \
                                      'First Seen [Here](https://redd.it/abc123) on 2019-01-28 68.75% match.\n\n' \
-                                     'Feedback? Hate? Visit r/repostsleuthbot - *I\'m not perfect, but you can help. Report [ [False Positive](https://www.reddit.com/message/compose/?to=RepostSleuthBot&subject=False%20Positive&message={"post_id": "abc123", "meme_template": null}) ]*\n\n' \
+                                     'Feedback? Hate? Visit r/repostsleuthbot - *I\'m not perfect, but you can help. Report [ [False Positive](<https://www.reddit.com/message/compose/?to=RepostSleuthBot&subject=False%20Positive&message={"post_id": "abc123", "meme_template": null}>) ]*\n\n' \
                                      '[View Search On repostsleuth.com](https://www.repostsleuth.com?postId=abc123&sameSub=false&filterOnlyOlder=true&memeFilter=false&filterDeadMatches=true&targetImageMatch=90&targetImageMemeMatch=50)\n\n' \
                                      '---\n\n' \
                                      '**Scope:** Reddit | **Meme Filter:** False | **Target:** 90% | **Check Title:** False | **Max Age:** 190' \
@@ -50,21 +50,21 @@ IMAGE_REPOST_ONE_MATCH_ALL_ENABLED = 'Looks like a repost. I\'ve seen this image
 
 IMAGE_REPOST_MULTI_MATCH_ALL_ENABLED = 'Looks like a repost. I\'ve seen this image 2 times.\n\n' \
                                      'First Seen [Here](https://redd.it/abc123) on 2019-01-28 68.75% match. Last Seen [Here](https://redd.it/123abc) on 2019-06-28 68.75% match\n\n' \
-                                     'Feedback? Hate? Visit r/repostsleuthbot - *I\'m not perfect, but you can help. Report [ [False Positive](https://www.reddit.com/message/compose/?to=RepostSleuthBot&subject=False%20Positive&message={"post_id": "abc123", "meme_template": null}) ]*\n\n' \
+                                     'Feedback? Hate? Visit r/repostsleuthbot - *I\'m not perfect, but you can help. Report [ [False Positive](<https://www.reddit.com/message/compose/?to=RepostSleuthBot&subject=False%20Positive&message={"post_id": "abc123", "meme_template": null}>) ]*\n\n' \
                                      '[View Search On repostsleuth.com](https://www.repostsleuth.com?postId=abc123&sameSub=false&filterOnlyOlder=true&memeFilter=false&filterDeadMatches=true&targetImageMatch=90&targetImageMemeMatch=50)\n\n' \
                                      '---\n\n' \
                                      '**Scope:** Reddit | **Meme Filter:** False | **Target:** 90% | **Check Title:** False | **Max Age:** 190' \
                                      ' | **Searched Images:** 0 | **Search Time:** 10s'
 
 IMAGE_REPOST_SUBREDDIT_CUSTOM =      'This is a custom repost template. 2 matches\n\n' \
-                                     'Feedback? Hate? Visit r/repostsleuthbot - *I\'m not perfect, but you can help. Report [ [False Positive](https://www.reddit.com/message/compose/?to=RepostSleuthBot&subject=False%20Positive&message={"post_id": "abc123", "meme_template": null}) ]*\n\n' \
+                                     'Feedback? Hate? Visit r/repostsleuthbot - *I\'m not perfect, but you can help. Report [ [False Positive](<https://www.reddit.com/message/compose/?to=RepostSleuthBot&subject=False%20Positive&message={"post_id": "abc123", "meme_template": null}>) ]*\n\n' \
                                      '[View Search On repostsleuth.com](https://www.repostsleuth.com?postId=abc123&sameSub=false&filterOnlyOlder=true&memeFilter=false&filterDeadMatches=true&targetImageMatch=90&targetImageMemeMatch=50)\n\n' \
                                      '---\n\n' \
                                      '**Scope:** Reddit | **Meme Filter:** False | **Target:** 90% | **Check Title:** False | **Max Age:** 190' \
                                      ' | **Searched Images:** 0 | **Search Time:** 10s'
 
 IMAGE_OC_SUBREDDIT_CUSTOM =      'This is a custom OC template. Random Sub test\n\n' \
-                                     'Feedback? Hate? Visit r/repostsleuthbot - *I\'m not perfect, but you can help. Report [ [False Negative](https://www.reddit.com/message/compose/?to=RepostSleuthBot&subject=False%20Negative&message={"post_id": "abc123", "meme_template": null}) ]*\n\n' \
+                                     'Feedback? Hate? Visit r/repostsleuthbot - *I\'m not perfect, but you can help. Report [ [False Negative](<https://www.reddit.com/message/compose/?to=RepostSleuthBot&subject=False%20Negative&message={"post_id": "abc123", "meme_template": null}>) ]*\n\n' \
                                      '[View Search On repostsleuth.com](https://www.repostsleuth.com?postId=abc123&sameSub=false&filterOnlyOlder=true&memeFilter=false&filterDeadMatches=true&targetImageMatch=90&targetImageMemeMatch=50)\n\n' \
                                      '---\n\n' \
                                      '**Scope:** Reddit | **Meme Filter:** False | **Target:** 90% | **Check Title:** False | **Max Age:** 190' \

--- a/tests/core/util/test_helpers.py
+++ b/tests/core/util/test_helpers.py
@@ -196,14 +196,14 @@ class TestHelpers(TestCase):
     def test_build_image_report_link_negative(self):
         search_results = ImageSearchResults('test.com', Mock(), checked_post=Post(post_id='abc123'))
         result = build_image_report_link(search_results)
-        expected = "*I'm not perfect, but you can help. Report [ [False Negative](https://www.reddit.com/message/compose/?to=RepostSleuthBot&subject=False%20Negative&message={\"post_id\": \"abc123\", \"meme_template\": null}) ]*"
+        expected = "*I'm not perfect, but you can help. Report [ [False Negative](<https://www.reddit.com/message/compose/?to=RepostSleuthBot&subject=False%20Negative&message={\"post_id\": \"abc123\", \"meme_template\": null}>) ]*"
         self.assertEqual(expected, result)
 
     def test_build_image_report_link_positive(self):
         search_results = ImageSearchResults('test.com', Mock(), checked_post=Post(post_id='abc123'))
         search_results.matches.append(ImageSearchMatch('test.com', 123, Mock(), 1, 1, 32))
         result = build_image_report_link(search_results)
-        expected = "*I'm not perfect, but you can help. Report [ [False Positive](https://www.reddit.com/message/compose/?to=RepostSleuthBot&subject=False%20Positive&message={\"post_id\": \"abc123\", \"meme_template\": null}) ]*"
+        expected = "*I'm not perfect, but you can help. Report [ [False Positive](<https://www.reddit.com/message/compose/?to=RepostSleuthBot&subject=False%20Positive&message={\"post_id\": \"abc123\", \"meme_template\": null}>) ]*"
         self.assertEqual(expected, result)
 
 


### PR DESCRIPTION
Hey! Love the project, only catch was for my Reddit app I was getting a few users complaining my Markdown renderer (which uses GitHub's renderer) doesn't render some of your links properly, e.g.: https://www.reddit.com/r/apolloapp/comments/s5tsk9/link_markdown_broken_i_think_it_has_to_do_with/

The "issue" (if you'd call it that) is that when you create the URL to PM you with, you include some JSON there that has spaces in it, which breaks GitHub's Markdown renderer. The Reddit website handles this properly somehow, but I thought I'd make a quick PR that wraps the URLs in <angled brackets> which per Commonmark (which Reddit also supports) [allows you to add spaces](https://superuser.com/questions/1170654/how-do-i-add-a-hyperlink-with-spaces-in-it-using-markdown) to URLs for increased compatibility. I updated the tests to reflect this.

tl;dr: shouldn't break anything but should increase compatibility.